### PR TITLE
Concurrent foldertree

### DIFF
--- a/girder/types.go
+++ b/girder/types.go
@@ -41,7 +41,9 @@ type Resource struct {
 	Path string
 	Size int64
 	Type string
-
+	Children []*Resource
+	
+	GirderParentID GirderID
 	GirderID   GirderID
 	GirderType string
 

--- a/girder/types.go
+++ b/girder/types.go
@@ -41,8 +41,8 @@ type Resource struct {
 	Path string
 	Size int64
 	Type string
-	Children []*Resource
-	
+	ChildrenFolders []*Resource // only for folders
+
 	GirderParentID GirderID
 	GirderID   GirderID
 	GirderType string

--- a/transfer/upload.go
+++ b/transfer/upload.go
@@ -34,7 +34,7 @@ func buildGirderDirs(ctx *girder.Context, baseDir string) {
 	}
 }
 
-func buildGirderDirsConcurrent(ctx *girder.Context) {
+func buildGirderFoldersConcurrent(ctx *girder.Context) {
 	// Adds all sibling folders concurrently.
 	rootDirsToBuild := make([]*girder.Resource, 0)
 	var numDirs int
@@ -235,7 +235,7 @@ func Upload(ctx *girder.Context, source string, destination girder.GirderID) {
 	ctx.Logger.Info("building remote girder directories")
 
 	//buildGirderDirs(ctx, source)
-	buildGirderDirsConcurrent(ctx)
+	buildGirderFoldersConcurrent(ctx)
 
 	ctx.Logger.Info("done building remote girder directories")
 

--- a/transfer/upload.go
+++ b/transfer/upload.go
@@ -86,10 +86,10 @@ func buildGirderDirsConcurrent(ctx *girder.Context) {
 func _uploadBytes(ctx *girder.Context, upload girder.GirderID, fullPath string, fi os.FileInfo) {
 
 	file, err := os.Open(fullPath)
-	if err != nil {
-		ctx.Logger.Warnf("failed to access %s, skipping. err: %s", fullPath, err)
+    if err != nil {
+        ctx.Logger.Warnf("failed to access %s, skipping. err: %s", fullPath, err)
 		return
-	}
+    }
 	defer file.Close()
 
 	totalChunks := util.Max(0, fi.Size()/maxChunkSize) + 1


### PR DESCRIPTION
I made a hash of this: whitespace issues and commented out a big block of the full upload for ease of local testing. I'll end up cleaning up this branch for commit history and whitespace then will resubmit after we work out the path forward.

Obviously feel free to drop whatever QA you want on me, here is my starting point for discussion:

Whitespace: should we run go format on everything? I haven't done this consistently, but easy enough.

`resources.go`: added a new function to `GetOrCreateFolder`, assumes the parent folder exists, what is the right way to check/enforce this?

`types.go`: added `GirderParentID` and `FolderChildren` fields. FolderChildren only applies for Folder resources. Should I split these field additions out into perhaps a new Folder type that composes the Resource type with these fields and is used only for uploading?

`upload.go`: the meat of the work is in the addition of the function `buildGirderFoldersConcurrent` and a bit of extra supporting data in `buildResourceMap`. I may want to play with the structure in `buildGirderFoldersConcurrent` as I saw some other concurrency patterns in the Go Programming book, also/related I don't know how the overall concurrency behaves in the face of error given that the main goroutine relies on creating the a priori known number of folders before exiting the `buildGirderFoldersConcurrent`  function.
